### PR TITLE
FSPT-157 Archival notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This concept was superseded by reducing the number of apps and duplicated requirements. At the time of archiving these are https://github.com/communitiesuk/funding-service-pre-award-frontend and https://github.com/communitiesuk/funding-service-pre-award-stores
+
 # funding-service-design-base
 Base images and requirements definitions for development of funding service design apps. These images are not used in production as those ones are build using Paketo.
 


### PR DESCRIPTION
We no longer need a base set of dependencies as there are fewer repositories that build with the same set of requirements. Point people to the relevant repositories if they come across the archived repo.